### PR TITLE
Add .vs/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ tests/kimai_server/data/kimai.sqlite
 /build/
 /dist/
 *.AppImage
+
+# ---> Visual Studio
+.vs/


### PR DESCRIPTION
I plan to contribute to the project since i'm using it for time tracking at my work,  
but Visual Studio automatically creates a .vs directory which would be tedious to remove in commits.

This commit adds the .vs/ directory to the .gitignore file.