### PR TITLE
Template button

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,8 @@ set(RESX
         resources/kemai.qrc
         ${KEMAI_L10N_QRC})
 
+qt_add_resources(${PROJECT_NAME} ${RESX})
+
 # OS Specifics
 if (WIN32)
     list(APPEND SRCS

--- a/src/gui/activityWidget.cpp
+++ b/src/gui/activityWidget.cpp
@@ -258,8 +258,6 @@ void ActivityWidget::onHistoryTimeSheetStartRequested(const TimeSheet& timeSheet
 
 void ActivityWidget::onHistoryTimeSheetFillRequested(const TimeSheet& timeSheet)
 {
-    //mPendingStartRequest = timeSheet;
-
     if (mSession->hasCurrentTimeSheet())
     {
         stopCurrentTimeSheet();

--- a/src/gui/activityWidget.cpp
+++ b/src/gui/activityWidget.cpp
@@ -251,8 +251,30 @@ void ActivityWidget::onHistoryTimeSheetStartRequested(const TimeSheet& timeSheet
     }
     else
     {
+        fillFromTimesheet(timeSheet);
         startPendingTimeSheet();
     }
+}
+
+void ActivityWidget::onHistoryTimeSheetFillRequested(const TimeSheet& timeSheet)
+{
+    //mPendingStartRequest = timeSheet;
+
+    if (mSession->hasCurrentTimeSheet())
+    {
+        stopCurrentTimeSheet();
+    }
+    fillFromTimesheet(timeSheet);
+}
+
+void ActivityWidget::fillFromTimesheet(const TimeSheet& timeSheet)
+{
+    mUi->cbCustomer->setCurrentIndex(mUi->cbCustomer->findData(timeSheet.project.customer.id));
+    updateProjectsCombo();
+    mUi->cbProject->setCurrentIndex(mUi->cbProject->findData(timeSheet.project.id));
+    mUi->cbActivity->setCurrentIndex(mUi->cbActivity->findData(timeSheet.activity.id));
+    mUi->pteDescription->setPlainText(timeSheet.description);
+    mUi->leTags->setText(timeSheet.tags.join(","));
 }
 
 void ActivityWidget::onBtStartStopClicked()
@@ -402,6 +424,7 @@ void ActivityWidget::updateRecentTimeSheetsView()
         mUi->lwHistory->setItemWidget(item, timeSheetListWidgetItem);
 
         connect(timeSheetListWidgetItem, &TimeSheetListWidgetItem::timeSheetStartRequested, this, &ActivityWidget::onHistoryTimeSheetStartRequested);
+        connect(timeSheetListWidgetItem, &TimeSheetListWidgetItem::timeSheetFillRequested, this, &ActivityWidget::onHistoryTimeSheetFillRequested);
     }
 }
 

--- a/src/gui/activityWidget.h
+++ b/src/gui/activityWidget.h
@@ -43,6 +43,8 @@ private:
     void onSessionCacheSynchronizeFinished();
 
     void onHistoryTimeSheetStartRequested(const TimeSheet& timeSheet);
+    void onHistoryTimeSheetFillRequested(const TimeSheet& timeSheet);
+    void fillFromTimesheet(const TimeSheet& timeSheet);
 
     void updateControls();
 

--- a/src/gui/settingsDialog.ui
+++ b/src/gui/settingsDialog.ui
@@ -229,7 +229,7 @@
              <item>
               <widget class="QToolButton" name="addProfileButton">
                <property name="icon">
-                <iconset resource="../resources/icons.qrc">
+                <iconset resource="../resources/kemai.qrc">
                  <normaloff>:/icons/add</normaloff>:/icons/add</iconset>
                </property>
               </widget>
@@ -256,7 +256,7 @@
                 <bool>false</bool>
                </property>
                <property name="icon">
-                <iconset resource="../resources/icons.qrc">
+                <iconset resource="../resources/kemai.qrc">
                  <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
                </property>
               </widget>
@@ -402,7 +402,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../resources/icons.qrc"/>
+  <include location="../resources/kemai.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/gui/taskWidget.ui
+++ b/src/gui/taskWidget.ui
@@ -35,7 +35,7 @@
         <string>...</string>
        </property>
        <property name="icon">
-        <iconset resource="../resources/icons.qrc">
+        <iconset resource="../resources/kemai.qrc">
          <normaloff>:/icons/refresh</normaloff>:/icons/refresh</iconset>
        </property>
       </widget>
@@ -86,7 +86,7 @@
   <tabstop>btClose</tabstop>
  </tabstops>
  <resources>
-  <include location="../resources/icons.qrc"/>
+  <include location="../resources/kemai.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/gui/timeSheetListWidgetItem.cpp
+++ b/src/gui/timeSheetListWidgetItem.cpp
@@ -16,6 +16,7 @@ TimeSheetListWidgetItem::TimeSheetListWidgetItem(const TimeSheet& timeSheet, QWi
     mUi->lbStartedAt->setText(timeSheet.beginAt.toString(Qt::ISODate));
 
     connect(mUi->btStart, &QPushButton::clicked, [this]() { emit timeSheetStartRequested(mTimeSheet); });
+    connect(mUi->btFill, &QPushButton::clicked, [this]() { emit timeSheetFillRequested(mTimeSheet); });
 }
 
 TimeSheetListWidgetItem::~TimeSheetListWidgetItem() = default;

--- a/src/gui/timeSheetListWidgetItem.h
+++ b/src/gui/timeSheetListWidgetItem.h
@@ -22,6 +22,7 @@ public:
 
 signals:
     void timeSheetStartRequested(const TimeSheet& timeSheet);
+    void timeSheetFillRequested(const TimeSheet& timeSheet);
 
 private:
     std::unique_ptr<Ui::TimeSheetListWidgetItem> mUi;

--- a/src/gui/timeSheetListWidgetItem.ui
+++ b/src/gui/timeSheetListWidgetItem.ui
@@ -31,6 +31,12 @@
    </property>
    <item>
     <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
@@ -40,9 +46,9 @@
      <property name="lineWidth">
       <number>1</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="spacing">
-       <number>2</number>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetNoConstraint</enum>
       </property>
       <property name="leftMargin">
        <number>2</number>
@@ -91,6 +97,16 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset theme="insert-text"/>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QPushButton" name="btStart">

--- a/src/gui/timeSheetListWidgetItem.ui
+++ b/src/gui/timeSheetListWidgetItem.ui
@@ -62,7 +62,54 @@
       <property name="bottomMargin">
        <number>2</number>
       </property>
-      <item>
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="lbStartedAt">
+          <property name="text">
+           <string>StartedAt</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="lbDuration">
+          <property name="text">
+           <string>duration</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lbDescription">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Description</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="lbActivity">
@@ -99,12 +146,25 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton">
+         <widget class="QPushButton" name="btFill">
+          <property name="toolTip">
+           <string>Use as template</string>
+          </property>
           <property name="text">
            <string/>
           </property>
           <property name="icon">
-           <iconset theme="insert-text"/>
+           <iconset resource="../resources/kemai.qrc">
+            <normaloff>:/icons/refresh</normaloff>:/icons/refresh</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="flat">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -115,6 +175,9 @@
             <width>32</width>
             <height>32</height>
            </size>
+          </property>
+          <property name="toolTip">
+           <string>Start again</string>
           </property>
           <property name="icon">
            <iconset resource="../resources/kemai.qrc">
@@ -127,54 +190,7 @@
            </size>
           </property>
           <property name="flat">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QLabel" name="lbDescription">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Description</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="lbStartedAt">
-          <property name="text">
-           <string>StartedAt</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="lbDuration">
-          <property name="text">
-           <string>duration</string>
+           <bool>false</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This adds a button next to the start new button but only fills in the values so you can correct them.

I was not aware of the button at all since it is flat and the icon is dark on my dark theme.

There seems to be a problem with the icon loading of the embedded icons. I was not able to track it down jet, I fixed the wrong references and added the missing cmake directive but that does not seem enough yet. Maybe it is SVG related. They are shown in qtcreator

I also don't think adding custom icons for a handful of icons is a good idea. Instead it would be better to reference the theme icons like "media-play". This way, the user can control the icons and they fit to the theme. I run a dark theme and the icons are not visible if they would load at all :)