### PR TITLE
Preserve combo box values on model refresh

### DIFF
--- a/src/gui/autoCompleteComboBox.h
+++ b/src/gui/autoCompleteComboBox.h
@@ -19,12 +19,27 @@ public:
 
     template<class K> void setKimaiData(const std::vector<K>& kds)
     {
+        auto current = QVariant();
         if (!mModelSet) // Avoid to call virtual setModel in ctor and to have to call explicitly somewhere else.
         {
             mModelSet = true;
             setModel(&mProxyModel);
         }
+        else
+        {
+            // Save which item was selected before the model reset
+            current = currentData();
+        }
         mModel.setKimaiData(kds);
+        if (!current.isNull())
+        {
+            // Find the item with a matching ID and make it current again
+            int foundIdx = findData(current, Qt::UserRole);
+            if (foundIdx > 0)
+            {
+                setCurrentIndex(foundIdx);
+            }
+        }
     }
 
     template<class K> void setFilter(const std::vector<K>& kds) { mProxyModel.setKimaiFilter(kds); }


### PR DESCRIPTION
Hello,

I understand a UI rewrite is underway :) but I started using Kimai with the `develop` version yesterday and really had to fix this by today :sweat_smile:. Not sure if it's a new regression but currently any refresh resets all combo boxes to blank, so this just carries the previously selected value over, if still present.

I have minimal experience with Qt (and may have missed a better way to do it), but hopefully this is simple enough to just work (it does for me).

Best regards,
Danko